### PR TITLE
Fix comment in kernels.h

### DIFF
--- a/algebra/kernels.h
+++ b/algebra/kernels.h
@@ -668,7 +668,7 @@ constexpr void __mul_karatsuba_rec(cnatural a, cnatural b, vnatural& q, uint64_t
         w += r.capacity;
         Check(w <= we);
         __mul_karatsuba_rec(aa, bb, r, w, we); // r = aa * bb
-        // TODO ^ How is this working? AA and BB are stored in Q and nested __mul_karatsuba_rec call will overwrite them? Tests are pasing with 256 words.
+        // TODO ^ How is this working? AA and BB are stored in Q and nested __mul_karatsuba_rec call will overwrite them? Tests are passing with 256 words.
 
         vnatural p {{w, 0}, a1.size + b1.size};
         w += p.capacity;


### PR DESCRIPTION
## Summary
- correct spelling in kernels implementation comment

## Testing
- `bazel test //...` *(fails: could not download Bazel)*

------
https://chatgpt.com/codex/tasks/task_e_6842133be19483268ff4aae5876dc420